### PR TITLE
Disallow semicolons forever and ever

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ module.exports = {
     "no-unused-vars": [1, {"vars": "all", "args": "after-used"}],
     "quotes": [2, "single"],
     "react/wrap-multilines": 1,
-    "semi": [2, "always"],
+    "semi": [2, "never"],
+    "semi-spacing": [2, { "before": false, "after": true }],
     "keyword-spacing": [2, {
       "before": false,
       "after": true,


### PR DESCRIPTION
A first step to approach [StandardJS](https://github.com/feross/eslint-config-standard). What does @vtex/developers think?

I personally see the community is leaning _heavily_ towards removing semi's lately. Personally, this makes sense to me since they 99.99% of the time don't add _any_ meaning - only noise. The other 0.01%, your script simply won't transpile if a semi is needed, so no worries there. 
