### PR TITLE
Add prefer-const rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ module.exports = {
     "one-var": [2, { "initialized": "never" }],
     "operator-linebreak": [2, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": [2, "never"],
+    "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "never"],
     "semi-spacing": [2, { "before": false, "after": true }],


### PR DESCRIPTION
A lot of projects that are using this lint, have variables declared with: "let" that never change.

I believe this rule is going to improve that part of the code:

http://eslint.org/docs/rules/prefer-const

Description:
If a variable is never reassigned, using the const declaration is better.
const declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.