### PR TITLE
Ignore prefer-const when destructuring

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = {
     "one-var": [2, { "initialized": "never" }],
     "operator-linebreak": [2, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": [2, "never"],
-    "prefer-const": 2,
+    "prefer-const": [2, { "destructuring": "all" }]
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "never"],
     "semi-spacing": [2, { "before": false, "after": true }],


### PR DESCRIPTION
Cenário:

```js
let {a, b} = obj;
a = a + 1;
```

Neste caso o eslint está reclamando pq `b` poderia ser const.

O que este PR faz é reclamar apenas no caso em que as duas variáveis deveriam ser const.

Mais sobre isso em: http://eslint.org/docs/rules/prefer-const#destructuring