### PR TITLE
Update compatibility eslint v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,26 +6,28 @@ module.exports = {
     "mocha": true,
     "es6": true
   },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "restParams": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true
+  "parserOptions": {
+    "ecmaFeatures": {
+      "arrowFunctions": true,
+      "blockBindings": true,
+      "classes": true,
+      "defaultParams": true,
+      "destructuring": true,
+      "modules": true,
+      "objectLiteralComputedProperties": true,
+      "objectLiteralShorthandMethods": true,
+      "objectLiteralShorthandProperties": true,
+      "restParams": true,
+      "spread": true,
+      "superInFunctions": true,
+      "templateStrings": true
+    }
   },
   "rules": {
     "arrow-spacing": [2, { "before": true, "after": true }],
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
-    "camelcase": [2, {"properties": "always"}],
+    "camelcase": [2, { "properties": "always" }],
     "comma-dangle": [2, "always-multiline"],
     "comma-spacing": [2, { "before": false, "after": true }],
     "comma-style": [2, "last"],
@@ -38,7 +40,7 @@ module.exports = {
     "handle-callback-err": [2, "^(err|error)$"],
     "indent": [2, 2, { "SwitchCase": 1 }],
     "jsx-quotes": [2, "prefer-double"],
-    "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
+    "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
     "new-cap": [2, { "newIsCap": true, "capIsNew": false }],
     "new-parens": 2,
     "no-array-constructor": 2,


### PR DESCRIPTION
Eslint v4 mudou a posição da chave `ecmaFeatures` (https://github.com/MoOx/eslint-loader/pull/178/files) que traz uma mensagem de erro no Vscode:

![screen shot 2017-07-25 at 12 08 33](https://user-images.githubusercontent.com/2573602/28579101-02c9bdb2-7132-11e7-8be8-d6793804a0cd.png)

Mudar a posição dessa chave para dentro de `parserOptions` concerta isso.