### PR TITLE
Disable no-console rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.2.0] - 2019-02-18
 ### Changed
 - Disable `no-console` rule for warnings and errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disable `no-console` rule.
 
 ## [9.1.0] - 2019-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Disable `no-console` rule.
+- Disable `no-console` rule for warnings and errors.
 
 ## [9.1.0] - 2019-02-06
 ### Added

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
       },
     ],
     "lodash/import-scope": [2, "method"],
-    "no-console": 0,
+    "no-console": ["error", { allow: ["warn", "error"] }],
   },
   env: {
     browser: true,

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
       },
     ],
     "lodash/import-scope": [2, "method"],
+    "no-console": 0,
   },
   env: {
     browser: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In inStore, we have this rule disabled in our configuration (which wasn't using `eslint-config-vtex`), but with the IO migration, the CLI overrides the config file and add this dependency.

The console statement is really useful for some error logging and this rule is annoying when we *want* to have a `console.error` in the code. I don't think it makes sense to remove all existing `console.error` calls in the codebase.