### PR TITLE
Fix imports errors and disable return-type rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Disabled rule `@typescript-eslint/explicit-function-return-type`.
+  - The current version of the parser doesn't have support for type analysis, so this rule will
+  complain for all functions, and not only the ones that doens't have a type signature or aren't
+  inferable.
 - Added typescript extensions for import plugin.
 
 ## [10.0.0] - 2019-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [10.0.1] - 2019-03-15
 ### Changed
 - Disabled rule `@typescript-eslint/explicit-function-return-type`.
   - The current version of the parser doesn't have support for type analysis, so this rule will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Disabled rule `@typescript-eslint/explicit-function-return-type`.
   - The current version of the parser doesn't have support for type analysis, so this rule will
-  complain for all functions, and not only the ones that doens't have a type signature or aren't
+  complain for all functions, and not only the ones that doesn't have a type signature or aren't
   inferable.
 - Added typescript extensions for import plugin.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disabled rule `@typescript-eslint/explicit-function-return-type`.
+- Added typescript extensions for import plugin.
 
 ## [10.0.0] - 2019-03-15
 ### Changed

--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ module.exports = {
   globals: {
     __DEV__: true,
   },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
 
   rules: {
     'prettier/prettier': 'error',
@@ -29,5 +36,7 @@ module.exports = {
     ],
     'lodash/import-scope': [2, 'method'],
     'no-console': ['error', { allow: ['warn', 'error'] }],
+
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
 }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'lodash/import-scope': [2, 'method'],
     'no-console': ['error', { allow: ['warn', 'error'] }],
 
+    // waiting for https://github.com/typescript-eslint/typescript-eslint/issues/50
     '@typescript-eslint/explicit-function-return-type': 'off',
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds the settings for the import plugin, so it doesn't complain about typescript files imports, and disable rule for explicit return type.

#### What problem is this solving?
Imports of typescript files were being shown as an error, altough the module existed.

And the explicit return type rule is annoying.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
