### PR TITLE
Remove eslint-plugin-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [10.1.0] - 2019-03-20
 ### Removed
 - Remove `eslint-plugin-import`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove `eslint-plugin-import`.
 
 ## [10.0.1] - 2019-03-15
 ### Changed

--- a/index.js
+++ b/index.js
@@ -2,12 +2,11 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:import/recommended',
     'plugin:prettier/recommended',
     'prettier',
     'prettier/@typescript-eslint',
   ],
-  plugins: ['@typescript-eslint', 'import', 'lodash', 'prettier'],
+  plugins: ['@typescript-eslint', 'lodash', 'prettier'],
 
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -16,24 +15,9 @@ module.exports = {
   globals: {
     __DEV__: true,
   },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      },
-    },
-  },
 
   rules: {
     'prettier/prettier': 'error',
-    'import/no-unresolved': [
-      'error',
-      {
-        commonjs: true,
-        amd: true,
-        ignore: ['^([a-zA-Z@]+[-\\.]?)+'],
-      },
-    ],
     'lodash/import-scope': [2, 'method'],
     'no-console': ['error', { allow: ['warn', 'error'] }],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "eslint-config-prettier": "^4.0.0",
-    "eslint-plugin-import": "^2.15.0",
     "eslint-plugin-lodash": "^5.1.0",
     "eslint-plugin-prettier": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the plugin `eslint-plugin-import`.

#### What problem is this solving?
This plugin doesn't account for the typescript interfaces import, and throws an error when there shouldn't be one. We are fine without it because typescript checks for the import paths of the modules, so this wasn't necessary anyway.

PS: This should be a major, but there isn't too many projects using this version anway.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
