### PR TITLE
Include ignore rest siblings to no-unused-vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,7 @@ module.exports = {
 
     // waiting for https://github.com/typescript-eslint/typescript-eslint/issues/50
     '@typescript-eslint/explicit-function-return-type': 'off',
+    
+    "@typescript-eslint/no-unused-vars": ["warn", { "ignoreRestSiblings": true }],
   },
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add `"@typescript-eslint/no-unused-vars": ["warn", { "ignoreRestSiblings": true }]` rule to `eslint` config.

#### What problem is this solving?
It solves the problem of some code like:

```
const { __emitter, __clearError, __errorInstance, ...props } = this.props

// ignore __emitter, __clearError, __errorInstance and do something with props
// ...
```

Yielding some `eslint` warning like:
```
.../render-runtime/react/utils/withHMR.tsx
  79:15  warning  '__emitter' is assigned a value but never used        @typescript-eslint/no-unused-vars
  79:26  warning  '__clearError' is assigned a value but never used     @typescript-eslint/no-unused-vars
  79:40  warning  '__errorInstance' is assigned a value but never used  @typescript-eslint/no-unused-vars
```

Even when the case of use is legitimate: removing `__emitter`, `__clearError` and `__errorInstance` from `props`.