### PR TITLE
Update dependencies versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [11.1.0] - 2019-09-16
 ### Changed
 - Bump `typescript-eslint` to `v2.3.0`.
 - Bump `eslint-plugin-lodash` to `v6.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Bump `typescript-eslint` to `v2.1.0`.
+- Bump `typescript-eslint` to `v2.3.0`.
 - Bump `eslint-plugin-lodash` to `v6.0.0`.
 - Bump `eslint-config-prettier` to `v6.2.0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump `typescript-eslint` to `v2.1.0`.
+- Bump `eslint-plugin-lodash` to `v6.0.0`.
+- Bump `eslint-config-prettier` to `v6.2.0`.
 
 ## [11.0.0] - 2019-07-15
 ### Changed

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/vtex/eslint-config-vtex#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.1.0",
-    "@typescript-eslint/parser": "^2.1.0",
+    "@typescript-eslint/eslint-plugin": "^2.3.0",
+    "@typescript-eslint/parser": "^2.3.0",
     "eslint-config-prettier": "^6.2.0",
     "eslint-plugin-lodash": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
   },
   "homepage": "https://github.com/vtex/eslint-config-vtex#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.12.0",
-    "@typescript-eslint/parser": "^1.12.0",
-    "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-lodash": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^2.1.0",
+    "@typescript-eslint/parser": "^2.1.0",
+    "eslint-config-prettier": "^6.2.0",
+    "eslint-plugin-lodash": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
+    "eslint": "^6.3.0",
     "prettier": "^1.18.2",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   },
   "peerDependencies": {
     "eslint": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Bump dependencies versions.

The bumped dependencies should have no effect on ours apps, and this should be released as a minor/patch and is not required to be a major. The `eslint-plugin-lodash` major bump was because they dropped support for Node 6, and the changes in `typescript-eslint` don't affect us.

#### What problem is this solving?
This fixes a warning when installing this package that `typescript-eslint` missed a peer dependency of `eslint@5`.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.