### PR TITLE
Add some eslint-plugin-import rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `eslint-plugin-import` to standardize import/export styles.
+
 ## [11.1.0] - 2019-09-16
 ### Changed
 - Bump `typescript-eslint` to `v2.3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [11.2.0] - 2019-10-31
+
 ### Added
 
 - Add `eslint-plugin-import` to standardize import/export styles.

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ module.exports = {
     'plugin:prettier/recommended',
     'prettier',
     'prettier/@typescript-eslint',
+    'plugin:import/typescript',
   ],
-  plugins: ['@typescript-eslint', 'lodash', 'prettier'],
+  plugins: ['@typescript-eslint', 'lodash', 'prettier', 'import'],
 
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -25,5 +26,27 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
 
     '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: [
+          'builtin',
+          'external',
+          ['internal', 'parent'],
+          ['sibling', 'index'],
+        ],
+      },
+    ],
+    'import/first': 'error',
+    'import/no-duplicates': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-mutable-exports': 'warn',
+    'import/export': 'warn',
+    'import/no-useless-path-segments': 'error',
+    'import/no-self-import': 'error',
+    'import/no-absolute-path': 'error',
   },
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "vtex"
   ],
   "author": "Breno Calazans",
+  "contributors": [
+    "Christian Kaisermann <christian.andrade@vtex.com.br>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/vtex/eslint-config-vtex/issues"
@@ -26,7 +29,8 @@
     "@typescript-eslint/parser": "^2.3.0",
     "eslint-config-prettier": "^6.2.0",
     "eslint-plugin-lodash": "^6.0.0",
-    "eslint-plugin-prettier": "^3.1.0"
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-import": "^2.18.2"
   },
   "devDependencies": {
     "eslint": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

As seen on:

https://vtex.slack.com/archives/CM2V0PELD/p1565203769033800?thread_ts=1565203769.033800&cid=CM2V0PELD

https://vtex.slack.com/archives/CM2V0PELD/p1572523462167100


#### What problem is this solving?

It standardize some import/export rules, mainly the ordering of import types.

#### How should this be manually tested?

1) `git clone` and enter the folder
2) `yarn link` to create a local link
3) go to a project which uses `eslint-config-vtex`
4) `yarn link eslint-config-vtex` to link to the local package
5) run your lint command

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/67971250-35cca080-fbeb-11e9-9d25-8846816e18ec.png)

![image](https://user-images.githubusercontent.com/12702016/67971268-41b86280-fbeb-11e9-9738-03b0da048cbd.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
