### PR TITLE
Add "files" prop to package.json for a better package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "https://github.com/vtex/eslint-config-vtex/issues"
   },
   "homepage": "https://github.com/vtex/eslint-config-vtex#readme",
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",


### PR DESCRIPTION
#### What is the purpose of this pull request?

The only file needed for the npm package is `index.js` (and npm's default ones). This PR aims to make the package smaller. #trivial

#### Screenshots or example usage

Before:
```
npm notice === Tarball Contents === 
npm notice 180B  .eslintrc.js                             
npm notice 1.4kB index.js                                 
npm notice 1.3kB package.json                             
npm notice 794B  .github/ISSUE_TEMPLATE/bug_report.md     
npm notice 1.4kB CHANGELOG.md                             
npm notice 559B  .github/ISSUE_TEMPLATE/feature_request.md
npm notice 582B  .github/PULL_REQUEST_TEMPLATE.md         
npm notice 322B  README.md                                
npm notice === Tarball Details === 
npm notice name:          eslint-config-vtex                      
npm notice version:       11.2.0                                  
npm notice package size:  2.9 kB                                  
npm notice unpacked size: 6.5 kB       
```

After:
```
npm notice 📦  eslint-config-vtex@11.1.0
npm notice === Tarball Contents === 
npm notice 762B  index.js    
npm notice 1.2kB package.json
npm notice 1.3kB CHANGELOG.md
npm notice 322B  README.md   
npm notice === Tarball Details === 
npm notice name:          eslint-config-vtex                      
npm notice version:       11.1.0                                  
npm notice package size:  1.6 kB                                  
npm notice unpacked size: 3.6 kB     
```

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
